### PR TITLE
Fix for issue #1. Add 55555 to SolaceInternalSecurityGroup

### DIFF
--- a/templates/solace-vmr.template
+++ b/templates/solace-vmr.template
@@ -669,6 +669,14 @@
                         "SourceSecurityGroupId": {
                             "Ref": "SolaceInternalSecurityGroupMember"
                         }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "55555",
+                        "ToPort": "55555",
+                        "CidrIp": {
+                            "Ref": "SolaceInternalSecurityGroupMember"
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Fix for config-sync issue when remote access CIDR does not include VRM internal IPs.